### PR TITLE
Turn on warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Default option is off.
 # We override this on the server for a test buid, so tests should be run with this on before checking in.
-option(ADDRESS_SANITISER_BUILD "Enable build settings to allow address sanitiser" OFF) # default to off
+option(ADDRESS_SANITISER_BUILD "Enable build settings to allow address sanitiser" ON) # default to off
 
 if(ADDRESS_SANITISER_BUILD)
 
@@ -109,6 +109,11 @@ if (NOT DEFINED libr_SOURCE_DIR)
     find_path(LIBR_DIRECTORY
             NAMES "CMakeLists.txt"
             PATHS ${LIBR_DIR})
+
+    #    Save the current Build test settings so we can restore them after including libr. We don't want to build libr tests.
+    SET(SAVED_TEST_OPTION BUILD_TESTS)
+    SET(BUILD_TESTS OFF)
+
     if (NOT LIBR_DIRECTORY)
         MESSAGE("RCOM - ${LIBR_DIR} does not exist. Downloading dependency.")
         MESSAGE("RCOM - WARNING")
@@ -128,6 +133,9 @@ if (NOT DEFINED libr_SOURCE_DIR)
         MESSAGE("RCOM - ${LIBR_DIRECTORY} exists. Not downloading dependency.")
         add_subdirectory(libr)
     endif()
+
+    # Restore build tests option.
+    SET(BUILD_TESTS OFF SAVED_TEST_OPTION)
 endif()
 
 ###########################################################3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ endif()
 
 # For now everything is debug. Set Compile options locally to maintain independent library builds.
 set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic ${PROJECT_SANITISE_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Werror ${PROJECT_SANITISE_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0")
-set(CMAKE_C_FLAGS "-Wall -Wextra -Wpedantic ${PROJECT_SANITISE_FLAGS}")
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wpedantic -Werror ${PROJECT_SANITISE_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-O0")
 
 set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} ${PROJECT_SANITISE_FLAGS}")
@@ -128,7 +128,6 @@ if (NOT DEFINED libr_SOURCE_DIR)
         MESSAGE("RCOM - ${LIBR_DIRECTORY} exists. Not downloading dependency.")
         add_subdirectory(libr)
     endif()
-#    add_subdirectory(${LIBR_DIR})
 endif()
 
 ###########################################################3

--- a/src/datahub.c
+++ b/src/datahub.c
@@ -56,8 +56,6 @@ datahub_t *new_datahub(datahub_onbroadcast_t onbroadcast,
                        datahub_ondata_t ondata,
                        void *userdata)
 {
-        int ret;
-        char n[80];
         datahub_t *hub;
 
         hub = r_new(datahub_t);
@@ -170,6 +168,7 @@ static addr_t *datahub_find(datahub_t *hub, addr_t *addr)
                 if (addr_eq(addr, a))
                         return a;
         }
+        return NULL;
 }
 
 int datahub_add_link(datahub_t* hub, addr_t *addr)
@@ -203,8 +202,6 @@ int datahub_add_link(datahub_t* hub, addr_t *addr)
 int datahub_remove_link(datahub_t* hub, addr_t *addr)
 {
         int ret = 0;
-
-        char b[64];
         //r_debug("datahub_remove_link: %s", addr_string(addr, b, sizeof(b)));
 
         datahub_lock(hub);
@@ -302,9 +299,6 @@ int datahub_send(datahub_t *hub, addr_t *link, data_t *m)
 
 static int datahub_send_locked(datahub_t *hub, addr_t *link, data_t *data, int stamp)
 {
-        list_t *l = hub->links;
-        list_t *rm = NULL;
-
         if (link == NULL || data == NULL) {
                 r_err("datahub_send_locked: invalid arguments");
                 return -1;

--- a/src/datalink.c
+++ b/src/datalink.c
@@ -168,8 +168,6 @@ json_object_t datalink_parse(datalink_t* link, data_t* data)
 
 int datalink_start_thread(datalink_t *link)
 {
-        int ret;
-        
         mutex_lock(link->mutex);
         if (link->thread == NULL) {
                 link->thread_quit = 0;

--- a/src/dump.c
+++ b/src/dump.c
@@ -281,7 +281,7 @@ int dump_read_data(dump_t *dump, data_t *data)
         int err;
         uint32_t n;
         
-        err = dump_read(dump, b, 4);
+        err = dump_read(dump, (char*)b, 4);
         if (err != 0)
                 return err;
         

--- a/src/http.c
+++ b/src/http.c
@@ -215,7 +215,7 @@ int http_send_headers(tcp_socket_t socket, int status,
                            "Access-Control-Allow-Origin: *\r\n"
                            "Connection: close\r\n\r\n",
                            status, http_status_string(status), mimetype, content_length);
-        if (len > sizeof(header) - 1) {
+        if ((unsigned)len > (sizeof(header) - 1)) {
                 r_err("http_send_headers: header fields too long");
                 return -1;
         }

--- a/src/messagehub.c
+++ b/src/messagehub.c
@@ -58,8 +58,6 @@ messagehub_t* new_messagehub(int port,
                              messagehub_onconnect_t onconnect,
                              void *userdata)
 {
-        int ret;
-        
         messagehub_t* hub = r_new(messagehub_t);
         if (hub == NULL)
                 return NULL;
@@ -157,9 +155,11 @@ addr_t *messagehub_addr(messagehub_t *hub)
 int messagehub_set_onrequest(messagehub_t *hub, messagehub_onrequest_t onrequest)
 {
         hub->onrequest = onrequest;
+        return 0;
 }
 
-static int messagehub_upgrade_connection(messagehub_t *hub,
+// ToDo: Why does this not use messagehub when it's called messagehub_XXX?
+static int messagehub_upgrade_connection(messagehub_t *hub __attribute__((unused)),
                                          request_t *request,
                                          tcp_socket_t link_socket)
 {
@@ -167,7 +167,7 @@ static int messagehub_upgrade_connection(messagehub_t *hub,
         unsigned char buffer[100];
         unsigned char digest[21];
         
-        snprintf(buffer, 100, "%s%s", key, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+        snprintf((char*)buffer, 100, "%s%s", key, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
         buffer[99] = 0;
 
         SHA1(buffer, digest);
@@ -311,7 +311,6 @@ static void messagehub_handle(messagehub_t *hub, tcp_socket_t link_socket)
 
 static void messagehub_wait_connection(messagehub_t *hub)
 {
-        messagelink_t *link;
         tcp_socket_t link_socket;
 
         //r_debug("messagehub_wait_connection");
@@ -421,7 +420,6 @@ int messagehub_broadcast_f(messagehub_t *hub, messagelink_t *exclude, const char
 {
         int err;
         va_list ap;
-        int len;
         
         if (messagehub_membuf(hub) != 0)
                 return -1;

--- a/src/net.c
+++ b/src/net.c
@@ -103,7 +103,7 @@ int udp_socket_wait_data(udp_socket_t socket, int timeout)
 
 int udp_socket_read(udp_socket_t socket, data_t *data, addr_t *addr)
 {
-        int addrlen = sizeof(addr_t);
+        u_int32_t addrlen = sizeof(addr_t);
         int len;
 
         len = recvfrom(socket,
@@ -238,7 +238,7 @@ int tcp_socket_read(tcp_socket_t socket, char *data, int len)
 tcp_socket_t open_server_socket(addr_t* addr)
 {
         int ret;
-        int socklen = sizeof(struct sockaddr_in);
+        uint32_t socklen = sizeof(struct sockaddr_in);
 
         int s = socket(AF_INET, SOCK_STREAM, 0);
         if (s == -1) {
@@ -266,7 +266,7 @@ tcp_socket_t open_server_socket(addr_t* addr)
 
 tcp_socket_t server_socket_accept(tcp_socket_t s)
 {
-        int addrlen = sizeof(struct sockaddr_in);
+        uint32_t addrlen = sizeof(struct sockaddr_in);
         struct sockaddr_in addr;
         int client = -1;
 
@@ -329,7 +329,7 @@ static int posix_wait_data(int socket, int timeout)
 static addr_t *posix_socket_addr(int s)
 {
         struct sockaddr_in local_addr;
-        int socklen = sizeof(&local_addr);        
+        uint32_t socklen = sizeof(&local_addr);
         memset((char *) &local_addr, 0, socklen);        
         getsockname(s, (struct sockaddr*) &local_addr, &socklen);
         return new_addr(inet_ntoa(local_addr.sin_addr),

--- a/src/rcgen.c
+++ b/src/rcgen.c
@@ -101,7 +101,7 @@ int print_main(membuf_t *buf)
         return 0;
 }
 
-int check_com_i(membuf_t *buf, json_object_t obj)
+int check_com_i(membuf_t *buf __attribute__((unused)), json_object_t obj)
 {
         const char *type = NULL;
         const char *topic = NULL;
@@ -150,7 +150,7 @@ int check_com(membuf_t *buf, json_object_t com)
         return 0;
 }
 
-int print_com_decl_i(membuf_t *buf, const char *name, json_object_t obj)
+int print_com_decl_i(membuf_t *buf, const char *name __attribute__((unused)), json_object_t obj)
 {
         const char *type = json_object_getstr(obj, "type");
         const char *topic = json_object_getstr(obj, "topic");
@@ -489,7 +489,6 @@ int print_new_streamer(membuf_t *buf,
         const char *onbroadcast = json_object_getstr(obj, "onbroadcast");
         const char *userdata = json_object_getstr(obj, "userdata");
         const char *mimetype = json_object_getstr(obj, "mimetype");
-        json_object_t resources;
         double port = 0;
 
         if (json_object_has(obj, "port")) {
@@ -616,7 +615,7 @@ int print_com_init(membuf_t *buf, const char *name, json_object_t com)
         return 0;
 }
 
-int print_com_controller_handlers(membuf_t *buf, const char *name, json_object_t obj)
+int print_com_controller_handlers(membuf_t *buf, const char *name __attribute__((unused)), json_object_t obj)
 {
         const char *topic = json_object_getstr(obj, "topic");
         json_object_t commands = json_object_get(obj, "commands");
@@ -702,9 +701,10 @@ int print_com_controller_handlers(membuf_t *buf, const char *name, json_object_t
         membuf_printf(buf, "        messagelink_set_onmessage(link, messagehub_%s_onmessage);\n", topic);
         membuf_printf(buf, "        return 0;\n");
         membuf_printf(buf, "}\n\n");
+        return 0;
 }
 
-int print_com_messagehub_handlers(membuf_t *buf, const char *name, json_object_t obj)
+int print_com_messagehub_handlers(membuf_t *buf, const char *name __attribute__((unused)), json_object_t obj)
 {
         const char *topic = json_object_getstr(obj, "topic");
         const char *onmessage = json_object_getstr(obj, "onmessage");
@@ -722,6 +722,7 @@ int print_com_messagehub_handlers(membuf_t *buf, const char *name, json_object_t
         membuf_printf(buf, "        messagelink_set_onmessage(link, (messagelink_onmessage_t) %s);\n", onmessage);
         membuf_printf(buf, "        return 0;\n");
         membuf_printf(buf, "}\n\n");
+        return 0;
 }
 
 int print_com_handlers(membuf_t *buf, const char *name, json_object_t com)
@@ -830,6 +831,7 @@ int print_init(membuf_t *buf, const char *name, const char *init_func)
                       "}\n");
         
         membuf_printf(buf, "\n");
+        return 0;
 }
        
 int print_cleanup(membuf_t *buf, const char *name, const char *cleanup_func)
@@ -844,6 +846,7 @@ int print_cleanup(membuf_t *buf, const char *name, const char *cleanup_func)
         }
         membuf_printf(buf, "        cleanup_com();\n}\n");
         membuf_printf(buf, "\n");
+        return 0;
 }
 
 int print_idle(membuf_t *buf, const char *idle_func)
@@ -856,6 +859,7 @@ int print_idle(membuf_t *buf, const char *idle_func)
                 membuf_printf(buf, "        clock_sleep(1.0);\n");
                 
         membuf_printf(buf, "}\n\n");
+        return 0;
 }
 
 int wite_code(const char *filename, membuf_t *buf)

--- a/src/rclaunch.c
+++ b/src/rclaunch.c
@@ -77,8 +77,6 @@ uid_t get_uid(const char *user);
 static int start_registry(pid_t gpid)
 {
         int ret;
-        int i;
-
         ret = run_start(_registry, gpid);
         if (ret == -1) {
                 r_err("start_registry: run_start_locally returned -1");
@@ -214,6 +212,7 @@ static list_t *delete_nodes(list_t *n)
         return NULL;
 }
 
+__attribute__((unused))
 static run_t *nodes_find(list_t *n, const char *name)
 {
         while (n) {
@@ -458,7 +457,6 @@ static int parse_general(json_object_t config)
 static int parse_registry(json_object_t config)
 {
         json_object_t r;
-        const char *name;
         const char *addr;
         const char *path;
         int port;
@@ -678,7 +676,6 @@ int main(int argc, char **argv)
 {
         pid_t child_pid =  -1;
         pid_t monitor_pid;
-        pid_t pid;
         int status;
         siginfo_t info;
         int ret;

--- a/src/rcquery.c
+++ b/src/rcquery.c
@@ -134,10 +134,10 @@ static void list_nodes()
         }
 }
 
-static void print_data(void *userdata,
-                       datalink_t *link,
+static void print_data(void *userdata __attribute__((unused)),
+                       datalink_t *link __attribute__((unused)),
                        data_t *data,
-                       data_t *out)
+                       data_t *out __attribute__((unused)))
 {
         printf("%.*s\n", data_len(data), data_data(data));
 }
@@ -155,8 +155,8 @@ static void listen_datahub(const char *topic)
         registry_close_datalink(link);
 }
 
-static void print_message(void *userdata,
-                          messagelink_t *link,
+static void print_message(void *userdata __attribute__((unused)),
+                          messagelink_t *link __attribute__((unused)),
                           json_object_t message)
 {
         json_print(message, 0);

--- a/src/rcregistry.c
+++ b/src/rcregistry.c
@@ -113,7 +113,7 @@ addr_t *rcregistry_addr(rcregistry_t *rcregistry)
 static int rcregistry_fail(messagelink_t *link, const char *req, const char *message)
 {
         r_warn("rcregistry_fail: %s: %s", req, message);
-        messagelink_send_f(link,
+        return messagelink_send_f(link,
                            "{\"request\":\"%s\", "
                            "\"success\":false, "
                            "\"message\":\"%s\"}",
@@ -122,7 +122,7 @@ static int rcregistry_fail(messagelink_t *link, const char *req, const char *mes
 
 static int rcregistry_success(messagelink_t *link, const char *req)
 {
-        messagelink_send_f(link, "{\"request\":\"%s\", \"success\":true}", req);
+        return messagelink_send_f(link, "{\"request\":\"%s\", \"success\":true}", req);
 }
 
 static void rcregistry_register(rcregistry_t* rcregistry,
@@ -131,8 +131,6 @@ static void rcregistry_register(rcregistry_t* rcregistry,
 {
         registry_entry_t *entry;
         int err;
-        int id;
-
         json_object_t obj = json_object_get(message, "entry");
         if (json_isnull(obj)) {
                 rcregistry_fail(link, "register-response", "Invalid entry value");
@@ -305,15 +303,15 @@ static void rcregistry_onmessage(rcregistry_t* rcregistry,
         }
 }
 
-static void rcregistry_onclose(rcregistry_t* rcregistry, messagelink_t *link)
+__attribute__((unused))
+static void rcregistry_onclose(rcregistry_t* rcregistry __attribute__((unused)) , messagelink_t *link __attribute__((unused)))
 {
         //r_debug("rcregistry: onclose");
-
         // TODO: remove all links and hubs related to this link?!
 }
 
 static int rcregistry_onconnect(rcregistry_t* rcregistry,
-                                messagehub_t *hub,
+                                messagehub_t *hub __attribute__((unused)),
                                 messagelink_t *link)
 {
         //r_debug("rcregistry: onconnect");
@@ -338,7 +336,8 @@ static void _onclose(void *userdata, messagelink_t *link)
 }
 
 static int _onconnect(void *userdata, messagehub_t *hub,
-                      request_t *request, messagelink_t *link)
+                      request_t *request __attribute__((unused)),
+                      messagelink_t *link)
 {
         rcregistry_t *rcregistry = (rcregistry_t *) userdata;
         rcregistry_onconnect(rcregistry, hub, link);

--- a/src/registry.c
+++ b/src/registry.c
@@ -112,8 +112,9 @@ void delete_registry_entry(registry_entry_t *entry)
                         r_free(entry->topic);
                 if (entry->addr)
                         delete_addr(entry->addr);
-                if (entry->endpoint)
-                        ; // FIXME!
+                // ToDo: This isn't created by the new fubction so we can't delete it can we?
+//                if (entry->endpoint)
+//                        ; // FIXME!
                 r_delete(entry);
         }
 }
@@ -127,7 +128,6 @@ registry_entry_t *registry_entry_parse(json_object_t obj, int *error)
         const char *addr_str;
         addr_t *addr;
         int type;
-        int err;
         
         id = json_object_getstr(obj, "id");
         name = json_object_getstr(obj, "name");
@@ -510,12 +510,16 @@ int registry_insert_entry(registry_t* registry, registry_entry_t *entry)
                                entry->type, entry->addr, entry->endpoint);
 }
 
+// ToDo: This seems wrong having two functions. We could use a recursive mutex.
+// ToDo: Just one lock function needed as anything calling it already has access to the lock.
 static int registry_remove_entry_locked(registry_t* registry, registry_entry_t *entry)
 {
         registry->entries = list_remove(registry->entries, entry);
         return 0;
 }
-        
+
+// ToDo: See above. Remove this function and rename the above.
+__attribute__((unused))
 static int registry_remove_entry(registry_t* registry, registry_entry_t *entry)
 {
         int r;

--- a/src/request.c
+++ b/src/request.c
@@ -136,7 +136,8 @@ json_object_t request_parse(request_t *r)
         return obj;
 }
 
-static int request_message_begin(http_parser *p)
+__attribute__((unused))
+static int request_message_begin(http_parser *p __attribute__((unused)))
 {
         return 0;
 }
@@ -271,7 +272,7 @@ int request_on_headers_complete(http_parser *p)
         // make a copy
         char uri[2048];
         int len = membuf_len(r->uri_buffer);
-        if (len > sizeof(uri)) {
+        if (len > (signed)sizeof(uri)) {
                 r_err("URI too long");
                 return -1;
         }
@@ -369,8 +370,8 @@ int request_parse_html(request_t *request, tcp_socket_t client_socket, int what)
                         return -1;
                 }
 
-                if (parsed != received
-                    && parsed != received - 1
+                if (parsed != (unsigned)received
+                    && parsed != (unsigned)received - 1
                     && request->continue_parsing) {
                         /* Handle error. Usually just close the connection. */
                         r_err("request_parse: parsed != received (%d != %d)",

--- a/src/response.c
+++ b/src/response.c
@@ -126,12 +126,14 @@ int response_set_onheaders(response_t *r, response_onheaders_t onheaders, void *
 {
         r->userdata = userdata;
         r->onheaders = onheaders;
+        return 0;
 }
 
 int response_set_ondata(response_t *r, response_ondata_t ondata, void *userdata)
 {
         r->userdata = userdata;
         r->ondata = ondata;
+        return 0;
 }
 
 static int response_add_header(response_t *r, const char *key, const char *value)
@@ -361,8 +363,8 @@ int response_parse_html(response_t *response, tcp_socket_t socket, int what)
                         if (received == 0)
                                 break;
                         
-                        if (parsed != received
-                            && parsed != received - 1) {
+                        if (parsed != (unsigned)received
+                            && parsed != ((unsigned)received - 1)) {
                                 /* Handle error. Usually just close the connection. */
                                 r_err("http_read_response: parsed != received (%d != %d)",
                                       (int) parsed, (int) received);
@@ -404,33 +406,11 @@ int response_printf(response_t *r, const char *format, ...)
     ret = membuf_vprintf(r->body, format, ap);
     va_end(ap);
 
-    if (r < 0) {
+    if (ret < 0) {
         r_err("response_printf: membuf_vprintf returned an error");
     }
     return ret;
 }
-
-//int response_printf(response_t *r, const char *format, ...)
-//{
-//        int len;
-//        va_list ap;
-//        int ret;
-//
-//        va_start(ap, format);
-//        len = vsnprintf(NULL, 0, format, ap);
-//        va_end(ap);
-//
-//        if (len < 0)
-//                return -1;
-//
-//        membuf_assure(r->body, len+1);
-//
-//        va_start(ap, format);
-//        ret = membuf_vprintf(r->body, format, ap);
-//        va_end(ap);
-//
-//        return ret;
-//}
 
 int response_send(response_t *response, tcp_socket_t client_socket)
 {

--- a/src/run.c
+++ b/src/run.c
@@ -196,7 +196,7 @@ static int get_user_info(const char *user, uid_t *uid, gid_t *gid)
         struct passwd pwbuf;
         struct passwd *pwbufp = NULL;
         char *buf;
-        size_t bufsize;
+        long bufsize;
 
         // From man getpwnam_r
         bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
@@ -211,7 +211,7 @@ static int get_user_info(const char *user, uid_t *uid, gid_t *gid)
 
         int err = getpwnam_r(user, &pwbuf, buf, bufsize, &pwbufp);
         if (pwbufp == NULL) {
-                if (err = 0) {
+                if (err == 0) {
                         r_err("Failed to obtain the UID associated with '%s'", user);
                         free(buf);
                         return -1;
@@ -263,7 +263,7 @@ static int run_start_locally(run_t *r)
 {
         char *argv[32];
 	pid_t pid;
-        int i, argc, err;
+        int argc, err;
         list_t *a = r->args;
         //char dump_arg[1024];
         
@@ -350,7 +350,7 @@ static int run_start_remotely(run_t *r)
 {
         char *argv[32];
 	pid_t pid;
-        int i, argc, err;
+        int argc, err;
         list_t *a = r->args;
 
         r_info("Starting '%s' remotely", r->name);
@@ -498,9 +498,6 @@ int run_stop(run_t *r)
         int err;
         int sig = SIGHUP;
         int count = 0;
-        pid_t p;
-        int status;
-        siginfo_t info;
 
         if (r->pid == -1)
                 return 0;
@@ -550,10 +547,10 @@ static int valid_info(const char *s,
                       int maxlen,
                       const char *valid_chars)
 {
-        int len, i;
+        size_t len, i;
         if (s == NULL)
                 return (minlen == 0);
-        if (strlen(s) < minlen || strlen(s) > maxlen)
+        if (strlen(s) < (unsigned)minlen || strlen(s) > (unsigned)maxlen)
                 return 0;
         len = strlen(s);
         for (i = 0; i < len; i++) {

--- a/src/service.c
+++ b/src/service.c
@@ -49,9 +49,6 @@ static void service_index_json(service_t* service, request_t *request, response_
 
 service_t* new_service(const char *name, int port)
 {
-        int ret;
-        int socklen = sizeof(struct sockaddr_in);
-        
         service_t* service = r_new(service_t);
         if (service == NULL)
                 return NULL;
@@ -157,7 +154,7 @@ addr_t *service_addr(service_t* service)
         return service->addr;
 }
 
-static void service_index_html(service_t* service, request_t *request, response_t *response)
+static void service_index_html(service_t* service, request_t *request __attribute__((unused)), response_t *response)
 {
         list_t *l;
         export_t *e;
@@ -199,7 +196,7 @@ static void service_index_html(service_t* service, request_t *request, response_
         response_printf(response, "  </body>\n</html>\n");
 }
 
-static void service_index_json(service_t* service, request_t *request, response_t *response)
+static void service_index_json(service_t* service, request_t *request __attribute__((unused)), response_t *response)
 {
         list_t *l;
         export_t *e;

--- a/src/streamerlink.c
+++ b/src/streamerlink.c
@@ -48,8 +48,8 @@ typedef struct _streamerlink_t {
 
 static int streamerlink_stop_thread(streamerlink_t *link);
 static int streamerlink_close_connection(streamerlink_t *link);
-static int streamerlink_lock(streamerlink_t *link);
-static int streamerlink_unlock(streamerlink_t *link);
+static void streamerlink_lock(streamerlink_t *link);
+static void streamerlink_unlock(streamerlink_t *link);
 
 streamerlink_t *new_streamerlink(streamerlink_ondata_t ondata,
                                  streamerlink_onresponse_t onresponse,
@@ -113,12 +113,12 @@ addr_t *streamerlink_addr(streamerlink_t *link)
         return link->addr;
 }
 
-static int streamerlink_lock(streamerlink_t *link)
+static void streamerlink_lock(streamerlink_t *link)
 {
         mutex_lock(link->mutex);
 }
 
-static int streamerlink_unlock(streamerlink_t *link)
+static void streamerlink_unlock(streamerlink_t *link)
 {
         mutex_unlock(link->mutex);
 }
@@ -220,8 +220,6 @@ static int streamerlink_ondata(void *userdata, response_t *response,
 
 static void streamerlink_run(streamerlink_t *link)
 {
-        size_t len = 80*1024;
-        char buf[len];
         int err;
 
         //r_debug("streamerlink_run: sending request");
@@ -262,7 +260,6 @@ cleanup:
 int streamerlink_connect(streamerlink_t *link)
 {
         int ret = 0;
-        char b[64];
         
         //r_debug("streamerlink_connect");
 

--- a/src/util.c
+++ b/src/util.c
@@ -51,7 +51,7 @@ unsigned char *SHA1(const unsigned char* s, unsigned char *digest)
 {
         SHA1_CTX context;        
         SHA1Init(&context);
-        SHA1Update(&context, s, strlen(s));
+        SHA1Update(&context, s, strlen((char*)s));
         SHA1Final(digest, &context);
         return digest;
 }
@@ -69,7 +69,7 @@ char *encode_base64(const unsigned char *s)
                 '4', '5', '6', '7', '8', '9', '+', '/'
         };
 
-        int ilen = strlen(s);
+        int ilen = strlen((char*)s);
         int olen = 4 * ((ilen + 2) / 3);
 
         char *t = r_alloc(olen+1);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,9 @@ add_test(
         COMMAND rcom_unit_tests
         )
 
-SETUP_TARGET_FOR_COVERAGE_LCOV(
+if(BUILD_COVERAGE)
+        SETUP_TARGET_FOR_COVERAGE_LCOV(
                             NAME rcom_unit_tests_coverage
                             EXECUTABLE ctest -V ${n_cores}
                             DEPENDENCIES rcom_unit_tests )
+endif()


### PR DESCRIPTION
Fix warnings.
Many functions just added attribute((unused)) this needs revisiting.
Issue exists in streamer.c (374) delete clients.