### PR TITLE
return default mimetype, naming links, and cleanup

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -37,7 +37,7 @@ addr_t *new_addr0()
 addr_t *new_addr(const char *ip, int port)
 {
         addr_t *addr = r_new(addr_t);
-        if (addr == NULL) return addr;
+
         addr->sin_family = AF_INET;
         if (addr_set(addr, ip, port) != 0) {
                 r_delete(addr);

--- a/src/http.c
+++ b/src/http.c
@@ -394,16 +394,21 @@ static mime_map_t map[] = { {".html", "text/html"},
 
 const char *filename_to_mimetype(const char *filename)
 {
+        const char *s = "application/octet-stream";
+        
         for (int i = 0; map[i].ext != NULL; i++) {
                 int n = strlen(map[i].ext);
                 int m = strlen(filename);
                 if (m < n + 1)
                         continue;
                 const char *p = filename + m - n;
-                if (rstreq(p, map[i].ext))
-                        return map[i].mimetype;
+                if (rstreq(p, map[i].ext)) {
+                        s = map[i].mimetype;
+                        break;
+                }
         }
-        return NULL;
+
+        return s;
 }
 
 const char *mimetype_to_fileextension(const char *mimetype)

--- a/src/messagehub_priv.h
+++ b/src/messagehub_priv.h
@@ -32,11 +32,13 @@ extern "C" {
 #endif
 
 // Set the port equal to 0 to let the OS pick one for you.
-messagehub_t *new_messagehub(int port,
+messagehub_t *new_messagehub(const char *name,
+                             int port,
                              messagehub_onconnect_t onconnect,
                              void *userdata);
 void delete_messagehub(messagehub_t *hub);
 addr_t *messagehub_addr(messagehub_t *hub);
+const char *messagehub_name(messagehub_t *hub);
 
 void messagehub_remove_link(messagehub_t *hub, messagelink_t *link);
                 

--- a/src/messagelink_priv.h
+++ b/src/messagelink_priv.h
@@ -35,7 +35,8 @@ typedef void (*messagelink_onpong_t)(messagelink_t *link,
                                      void *userdata,
                                      const char *data, int len);
 
-messagelink_t *new_messagelink(messagelink_onmessage_t onmessage,
+messagelink_t *new_messagelink(const char *name,
+                               messagelink_onmessage_t onmessage,
                                messagelink_onclose_t onclose,
                                void *userdata);
 void delete_messagelink(messagelink_t *link);

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -214,7 +214,8 @@ static proxy_t* new_proxy(addr_t *addr)
         }
         
         if (addr) {
-                proxy->link = new_messagelink(_proxy_onmessage,
+                proxy->link = new_messagelink("registry",
+                                              _proxy_onmessage,
                                               _proxy_onclose,
                                               proxy);
 
@@ -932,7 +933,7 @@ static messagelink_t *proxy_open_messagelink(proxy_t *proxy,
         messagelink_t *link;
         registry_entry_t *entry;
 
-        link = new_messagelink(onmessage, NULL, userdata);
+        link = new_messagelink(topic, onmessage, NULL, userdata);
         if (link == NULL)
                 return NULL;
 
@@ -979,7 +980,7 @@ static messagehub_t *proxy_open_messagehub(proxy_t *proxy,
         messagehub_t *hub;
         registry_entry_t *entry;
 
-        hub = new_messagehub(port, onconnect, userdata);
+        hub = new_messagehub(topic, port, onconnect, userdata);
         if (hub == NULL)
                 return NULL;
 

--- a/src/rclaunch.c
+++ b/src/rclaunch.c
@@ -374,12 +374,6 @@ static int parse_general(json_object_t config)
                 return 0;
         }
 
-        /* const char *log = json_object_getstr(r, "log-dir"); */
-        /* if (log != NULL) { */
-        /*         // app_set_logdir also update the log file. */
-        /*         app_set_logdir(log); */
-        /* } */
-
         const char *user = json_object_getstr(r, "user");
         if (user != NULL) {
                 _user = r_strdup(user);
@@ -422,26 +416,6 @@ static int parse_general(json_object_t config)
                 rprintf(path, sizeof(path), "%s/%s", sessions_dir, datetime);
                 app_set_session(path);
         }
-
-        /* _dump_dir = json_object_getstr(r, "dump-dir"); */
-        /* if (_dump_dir != NULL && get_dumping()) { */
-        /*         char path[1024]; */
-        /*         char timestamp[128]; */
-        /*         int err; */
-
-        /*         clock_datetime(timestamp, 128, '-', '_', '-'); */
-        /*         snprintf(path, 1024, "%s/%s", _dump_dir, timestamp); */
-        /*         path[1023] = 0; */
-
-        /*         err = mkdir(path, 0777); */
-        /*         if (err != 0) { */
-        /*                 char reason[200]; */
-        /*                 strerror_r(errno, reason, 200); */
-        /*                 r_err("Failed to create the directory '%s'", path); */
-        /*                 return -1; */
-        /*         } */
-        /*         set_dumping_dir(path); */
-        /* } */
 
         /* _replay_path = json_object_getstr(r, "replay-path"); */
         /* if (_replay_path == NULL) { */

--- a/src/rcregistry.c
+++ b/src/rcregistry.c
@@ -73,7 +73,8 @@ rcregistry_t* new_rcregistry()
                 return NULL;
         }
         
-        rcregistry->hub = new_messagehub(get_registry_port(), _onconnect, rcregistry);
+        rcregistry->hub = new_messagehub("registry", get_registry_port(),
+                                         _onconnect, rcregistry);
         if (rcregistry->hub == NULL) {
                 r_err("Failed to create the registry hub. Quiting.");
                 delete_rcregistry(rcregistry);

--- a/src/response.c
+++ b/src/response.c
@@ -51,47 +51,27 @@ struct _response_t {
 response_t *new_response(int status)
 {
         response_t *r = r_new(response_t);
-        if (r == NULL)
-                return NULL;
-
         r->status = status;
         r->headers = 0;
         r->body = new_membuf();
-        if (r->body == NULL) {
-                delete_response(r);
-                return NULL;
-        }
-
-        //r->cur_header = NULL;
         r->parser_header_state = k_header_new;
         r->header_name = new_membuf();
         r->header_value = new_membuf();
         r->status_buffer = new_membuf();
-        
-        if (r->header_name == NULL
-            || r->header_value == NULL
-            || r->status_buffer == NULL) {
-                delete_response(r);
-                return NULL;
-        }
         return r;
 }
 
 void delete_response(response_t *r)
 {
         if (r) {
-                if (r->body)
-                        delete_membuf(r->body);                
+                delete_membuf(r->body);                
                 for (list_t *l = r->headers; l != NULL; l = list_next(l)) {
                         http_header_t *h = list_get(l, http_header_t);
                         delete_http_header(h);
                 }
-                if (r->header_name)
-                        delete_membuf(r->header_name);
-                if (r->header_value)
-                        delete_membuf(r->header_value);                
-                if (r->status_buffer)
-                        delete_membuf(r->status_buffer);                
+                delete_membuf(r->header_name);
+                delete_membuf(r->header_value);                
+                delete_membuf(r->status_buffer);                
                 delete_list(r->headers);
                 r_delete(r);
         }


### PR DESCRIPTION
- filename_to_mimetype returns a default mimetype is none was found
- messagelinks and messagehubs have a name, to simplify debugging
- code clean: removing testing for NULL after memory allocation and before freeing/deleting
