### PR TITLE
Messagelink topic and proxy protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,19 @@ There are four type of communication between nodes:
 
 Data messages are implemented on top of UDP and are therefore limited in size (1.5kB). Messagehub use WebSockets to pass data. Services use classical HTTP requests. Streamers use HTTP request and return the data using the multipart/x-mixed-replace format.
 
+Although the data messages are agnostic about the content of the messages most messages are encoded in JSON. Message hubs always use JSON encoded messages. 
+
 In addition, to those four basic link types, the rcgen utility (discussed below) recognizes the "controller" type. A controller is a messagehub that expects a command/response interaction.
+
+All end-points have a type, a topic, and an address. The address is a combination of IP address and port number. The possible types are: datahub, datalink, messagehub, messagelink, service, streamer, streamerlink.
+
+Both datahubs and messagehubs create one-to-many connections, with many links connected to the same hub. There can be only one messagehub for a given topic but there can be both a datahub and a messagehub with the same topic because there is no ambiguity between the two.
+
 
 The rcom library does not have a "bus" type of communication but it can be built quite easily using a messagehub. 
 
-Although the connections are agnostic about the content of the messages most messages are encoded in JSON.  
-
-
-
-
 There are several utilities:
-* rcregistry: 
+* rcregistry: Maintains the list of all the rcom end-points, inluding their type, topic, and address. 
 * rcom: The application offers a number of utility functions, inluding querying the registry, listening to the message of nodes.
 * rclaunch: 
 * rcgen: takes a description of an app as input and generates C code that provides a skeleton for the app.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,130 @@
+
+TODO: check https://www.jsonrpc.org/specification
+
+
+# Registry
+
+The registry has two types of interactions with the other nodes:
+
+* Request/response: Nodes can send requests to the registry, such as
+  register/unregister. The registry will send a response to signal the
+  success of the request and possible pass a return value.
+* Events: Nodes get notified when nodes appear or dissappear. Events
+  are sent only by the registry to all nodes in the network.
+
+
+## Example
+
+Request:
+
+```json
+{"request": "list"}
+```
+
+Response:
+
+```json
+{
+  "response": "list-response",
+  "success": true,
+  "list": [
+    {
+      "name": "registry",
+      "id": "ed8ae24b-fbfe-4320-ae2e-4115e95b9c6d",
+      "type": "messagehub",
+      "topic": "registry",
+      "addr": "0.0.0.0:10101"
+    },
+    {
+      "name": "configuration",
+      "id": "289a0c98-6bed-4336-92b3-c04b806f36f1",
+      "type": "service",
+      "topic": "configuration",
+      "addr": "0.0.0.0:47275"
+    },
+    {
+      "name": "configuration",
+      "id": "c4d06932-1552-4905-a6ed-f2c59350c0eb",
+      "type": "messagelink",
+      "topic": "logger",
+      "addr": "0.0.0.0:0"
+    }
+  ]
+}
+```
+
+## Entry object
+
+The entry object describes a communication end-point in the
+network.
+
+The possible types of end-points are: datahub, datalink, messagehub,
+messagelink, service, streamer, and streamerlink.
+
+Hubs, streamers, and services are uniquely identified by their type
+and topic. So there can be only one datahub called "encoders", or one
+streamer called "camera". However, their can be many (client-)links
+that are interested in the same topic.
+
+The entry object is used in the several requests and events. It is a
+JSON object with the following fields:
+
+
+| Name  | Type   | Description  |
+| ----- | ------ | ------------ |
+| id    | String | The internal ID |
+| name  | String | The user-given name |
+| type  | String | The type of the entry (datahub, datalink, messagehub, ...). |
+| topic | String | The topic of this entry |
+| addr  | String | The IP address of the entry (useful only for hubs and streamers) |
+
+
+## Requests and responses
+
+### Request object
+
+A request is a JSON-encoded object. It's main field is `request`. The
+possible request values are:
+
+
+### Request values
+
+| Value          | Description | Response    | Event        |
+| -------------- | -------- | -------------- | ------------ |
+| register       | To register a new entry | register-response       | proxy-add    |
+| unregister     | To unregister a new entry | unregister-response     | proxy-remove |
+| update-address | To update the address of a entry | update-address-response | proxy-update-address |
+| list           | To list all the available entries | list-response           | - |
+
+
+### Response object
+
+A JSON object with the following fields:
+
+| Name     | Type    | Description  |
+| -------- | ------- | ------------ |
+| response | String  | One of the values from the table below |
+| success  | Boolean | Whether the request was executed succesfully or not |
+| message  | String  | An error message. Only informative when success is false. |
+| list     | Array of entries | Used only by "list" requests |
+
+
+The `response` field takes the same value as the original request:
+`register`, `unregister`, `update-address`, or `list`.
+
+
+## Events
+
+Events are sent by the registry when the overlay network changes. Events are coded in JSON as follows.
+
+### Event object
+
+An event is a JSON object with the field `event` set to one of the
+following values:
+
+| Value                | Description |
+| -------------------- | ----------- | 
+| proxy-add            | A new entry was registered. |
+| proxy-remove         |  |
+| proxy-update-address |  |
+

--- a/src/messagehub_priv.h
+++ b/src/messagehub_priv.h
@@ -33,12 +33,14 @@ extern "C" {
 
 // Set the port equal to 0 to let the OS pick one for you.
 messagehub_t *new_messagehub(const char *name,
+                             const char *topic,
                              int port,
                              messagehub_onconnect_t onconnect,
                              void *userdata);
 void delete_messagehub(messagehub_t *hub);
 addr_t *messagehub_addr(messagehub_t *hub);
 const char *messagehub_name(messagehub_t *hub);
+const char *messagehub_topic(messagehub_t *hub);
 
 void messagehub_remove_link(messagehub_t *hub, messagelink_t *link);
                 

--- a/src/messagelink_priv.h
+++ b/src/messagelink_priv.h
@@ -36,6 +36,7 @@ typedef void (*messagelink_onpong_t)(messagelink_t *link,
                                      const char *data, int len);
 
 messagelink_t *new_messagelink(const char *name,
+                               const char *topic,
                                messagelink_onmessage_t onmessage,
                                messagelink_onclose_t onclose,
                                void *userdata);
@@ -54,6 +55,8 @@ void messagelink_read_in_background(messagelink_t *link);
 int messagelink_send_ping(messagelink_t *link, const char *data, int len);
 
 addr_t *messagelink_addr(messagelink_t *link);
+const char *messagelink_name(messagelink_t *link);
+const char *messagelink_topic(messagelink_t *link);
 
 void messagelink_stop_thread(messagelink_t *link);
 


### PR DESCRIPTION
Messagelinks and messagehub know their topic. This is useful for debugging.
The protocol between the central registry and the proxies has been cleaned up. It now makes a distinginction between responses to a request and update events. 
A first draft of the documentation of this protocol is available, too.
  