### PR TITLE
better handling of invalid websocket handshakes

### DIFF
--- a/src/messagehub.c
+++ b/src/messagehub.c
@@ -218,6 +218,15 @@ static void messagehub_handle_websocket(messagehub_t* hub,
                                         request_t *request,
                                         tcp_socket_t link_socket)
 {
+        if (!request_is_valid_websocket(request)) {
+                http_send_error_headers(link_socket, HTTP_Status_Bad_Request);
+                r_debug("messagehub_handle_websocket: close_tcp_socket");
+                r_info("messagehub_handle_websocket: invalid websocket request");
+                close_tcp_socket(link_socket);
+                delete_request(request);
+                return;
+        }
+
         if (messagehub_upgrade_connection(hub, request, link_socket) != 0) {
                 http_send_error_headers(link_socket, HTTP_Status_Internal_Server_Error);
                 r_debug("messagehub_handle_websocket: close_tcp_socket");

--- a/src/request_priv.h
+++ b/src/request_priv.h
@@ -57,6 +57,7 @@ int request_parse_html(request_t *request, tcp_socket_t client_socket, int what)
 /* int request_on_headers_complete(http_parser *p); */
 
 int request_is_websocket(request_t *r);
+int request_is_valid_websocket(request_t *r);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The handling of a WebSocket request did not correctly distinguish between a valid and an invalid WebSocket request (ex. a request that misses a required header field). Because of this invalid request were then interpreted as a standard HTTP request instead of returning a "400 Bad Request" status code.

